### PR TITLE
Fix typo in storage profile comment

### DIFF
--- a/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateTable.java
+++ b/modules/sql-engine/src/main/java/org/apache/ignite/internal/sql/engine/sql/IgniteSqlCreateTable.java
@@ -160,7 +160,7 @@ public class IgniteSqlCreateTable extends SqlCreate {
     }
 
     /**
-     * Get storage profile identifier to create teh table.
+     * Get storage profile identifier to create the table.
      */
     public @Nullable SqlNode storageProfile() {
         return storageProfile;


### PR DESCRIPTION
## Summary
- correct 'teh table' typo in IgniteSqlCreateTable javadoc

## Testing
- `./gradlew :ignite-sql-engine:checkstyleMain`
- `./gradlew :ignite-sql-engine:test --tests org.apache.ignite.internal.lang.SqlExceptionMapperUtilTest`

------
https://chatgpt.com/codex/tasks/task_e_6860089d04008325ac89147b6a7c4940